### PR TITLE
Campaign identifier constant

### DIFF
--- a/src/SalesChamp/Webhooks/Headers.php
+++ b/src/SalesChamp/Webhooks/Headers.php
@@ -11,4 +11,6 @@ abstract class Headers
 	const SIGNATURE = 'X-SalesChamp-Signature';
 
 	const IDENTIFIER = 'X-SalesChamp-Id';
+
+	const CAMPAIGN = 'X-Campaign-Id';
 }


### PR DESCRIPTION
Constant for campaign identifier that's included in HTTP requests included.